### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -44,7 +44,7 @@
         function getType(){ return 'substition'; }
         function getSort(){ return 999; }
         function connectTo($mode) { $this->Lexer->addSpecialPattern('{rdplink:.+?}',$mode,'plugin_rdplink'); }
-        function handle($match, $state, $pos, &$handler){
+        function handle($match, $state, $pos, Doku_Handler $handler){
             switch ($state) {
               case DOKU_LEXER_SPECIAL :
                 $match = substr($match,9,-1);
@@ -59,7 +59,7 @@
             return array();
         }
      
-        function render($mode, &$renderer, $data) {
+        function render($mode, Doku_Renderer $renderer, $data) {
             if($mode == 'xhtml'){
     //            $renderer->doc .= "<a href=\"" . DOKU_URL . "lib/plugins/rdplink/rdp.php?server=" . $data['server'] . "\"><img src=\"".DOKU_URL."lib/plugins/rdplink/rdpicon.png\" />" . $data['desc'] . "</a>";
                 $renderer->doc .= "<img src=\"".DOKU_URL."lib/plugins/rdplink/rdpicon.png\" />&nbsp;<a href=\"" . DOKU_URL . "lib/plugins/rdplink/rdp.php?server=" . $data['server'] . "\">" . $data['desc'] . "</a>";


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
